### PR TITLE
Add ./docs GitHub Pages with Docute.

### DIFF
--- a/docs/config.js
+++ b/docs/config.js
@@ -1,0 +1,4 @@
+self.$config = {
+	home: 'https://raw.githubusercontent.com/pablohpsilva/vuejs-component-style-guide/master/README.md',
+	repo: 'pablohpsilva/vuejs-component-style-guide'
+};

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
+	<title>Vue.js Component Style Guide</title>
+	<link rel="stylesheet" href="https://unpkg.com/docute@2/dist/docute.css">
+</head>
+<body>
+	<!-- don't remove this part start -->
+	<div id="app"></div>
+	<script src="./config.js"></script>
+	<script src="https://unpkg.com/docute@2/dist/docute.js"></script>
+	<!-- don't remove this part end -->
+</body>
+</html>


### PR DESCRIPTION
Add `./docs` [GitHub Pages](https://pages.github.com/) with [📜 Docute](https://github.com/egoist/docute).
For better navigation.

Just set GitHub Pages to `./docs` and visit https://pablohpsilva.github.io/vuejs-component-style-guide