### PR TITLE
update english README to include mixins in component structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ Component structure:
   export default {
     // Do not forget this little guy
     name: 'RangeSlider',
+    // share common functionality with component mixins
+    mixins: [],
     // compose new components
     extends: {},
     // component properties/variables


### PR DESCRIPTION
Mixins added above props and below the name as I believe it ranks in priority due to potentially "mixing in" props, methods, etc..