### PR TITLE
style name should use `name`  attribute in script

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Component structure:
 
 ```html
 <template lang="html">
-  <div class="Ranger__Wrapper">
+  <div class="RangeSlider__Wrapper">
     <!-- ... -->
   </div>
 </template>
@@ -324,7 +324,7 @@ Component structure:
 </script>
 
 <style scoped>
-  .Ranger__Wrapper { /* ... */ }
+  .RangeSlider__Wrapper { /* ... */ }
 </style>
 ```
 


### PR DESCRIPTION
`Range` is used in `style` and `template` while `name` in script is `RangeSlider`