### PR TITLE
Update link to "valid custom element name" spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Each component name must be:
 
 Vue component names must also be:
 
-* **Custom element spec compliant**: [include a hyphen](https://www.w3.org/TR/custom-elements/#concepts), don't use reserved names.
+* **Custom element spec compliant**: [include a hyphen](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name), don't use reserved names.
 * **`app-` namespaced**: if very generic and otherwise 1 word, so that it can easily be reused in other projects.
 
 ### Why?


### PR DESCRIPTION
The old reference no longer exists.

The same change was made in the "upstream" Riot Style Guide repository: https://github.com/voorhoede/riotjs-style-guide/pull/65/commits/c60d7863e8a095965025974f1414f44317f2ff4d